### PR TITLE
Bump plexus-compiler-javac-errorprone from 2.8.3 to 2.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
                             <dependency>
                                 <groupId>org.codehaus.plexus</groupId>
                                 <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.8.3</version>
+                                <version>2.8.6</version>
                             </dependency>
                             <!-- override plexus-compiler-javac-errorprone's dependency on
                                  Error Prone with the latest version -->


### PR DESCRIPTION
Bumps plexus-compiler-javac-errorprone from 2.8.3 to 2.8.6.