### PR TITLE
Bump version.junit-jupiter from 5.4.2 to 5.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
         <version.jackson>[2.10.0,)</version.jackson>
-        <version.junit-jupiter>5.4.2</version.junit-jupiter>
+        <version.junit-jupiter>5.6.2</version.junit-jupiter>
         <version.junit.vintage>4.12</version.junit.vintage>
         <version.junit-vintage-engine>5.3.2</version.junit-vintage-engine>
         <version.logback>1.2.3</version.logback>


### PR DESCRIPTION
Bumps `version.junit-jupiter` from 5.4.2 to 5.6.2.

Updates `junit-jupiter-engine` from 5.4.2 to 5.6.2
<details>
<summary>Release notes</summary>

*Sourced from [junit-jupiter-engine's releases](https://github.com/junit-team/junit5/releases).*

> JUnit 5.6.2 = Platform 1.6.2 + Jupiter 5.6.2 + Vintage 5.6.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.2/release-notes/).
> 
> JUnit 5.6.1 = Platform 1.6.1 + Jupiter 5.6.1 + Vintage 5.6.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.1/release-notes/).
> 
> JUnit 5.6.0 = Platform 1.6.0 + Jupiter 5.6.0 + Vintage 5.6.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0/release-notes/).
> 
> JUnit 5.6.0-RC1 = Platform 1.6.0-RC1 + Jupiter 5.6.0-RC1 + Vintage 5.6.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-RC1/release-notes/).
> 
> JUnit 5.6.0-M1 = Platform 1.6.0-M1 + Jupiter 5.6.0-M1 + Vintage 5.6.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-M1/release-notes/).
> 
> JUnit 5.5.2 = Platform 1.5.2 + Jupiter 5.5.2 + Vintage 5.5.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.2/release-notes/).
> 
> JUnit 5.5.1 = Platform 1.5.1 + Jupiter 5.5.1 + Vintage 5.5.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.1/release-notes/).
> 
> JUnit 5.5.0 = Platform 1.5.0 + Jupiter 5.5.0 + Vintage 5.5.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0/release-notes/).
> 
> JUnit 5.5.0-RC2 = Platform 1.5.0-RC2 + Jupiter 5.5.0-RC2 + Vintage 5.5.0-RC2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC2/release-notes/).
> 
> JUnit 5.5.0-RC1 = Platform 1.5.0-RC1 + Jupiter 5.5.0-RC1 + Vintage 5.5.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC1/release-notes/).
> 
> JUnit 5.5.0-M1 = Platform 1.5.0-M1 + Jupiter 5.5.0-M1 + Vintage 5.5.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-M1/release-notes/).
</details>
<details>
<summary>Commits</summary>

- [`4e7a087`](https://github.com/junit-team/junit5/commit/4e7a087e052d982ec02a75da4a2c1f6cc34abde2) Release 5.6.2
- [`0be02cf`](https://github.com/junit-team/junit5/commit/0be02cf2e13a5de89b087be340a1d4b81d60eb69) Determine releaseBranch automatically based on version
- [`11ddd87`](https://github.com/junit-team/junit5/commit/11ddd8766b8e5ca661ca554a3c144673180fbc15) Avoid inner class cycle detection for non-matching predicate
- [`5cbfed5`](https://github.com/junit-team/junit5/commit/5cbfed57281dd70b3695b2daeaf35b7941a7e5e0) Remove irrelevant sections
- [`648121d`](https://github.com/junit-team/junit5/commit/648121d8b665836e5b88fa492462ab978431c777) Document [#2248](https://github-redirect.dependabot.com/junit-team/junit5/issues/2248) in release notes
- [`ef6e842`](https://github.com/junit-team/junit5/commit/ef6e842d1f1092d125abc17f636489f44daf5419) Add release notes for 5.6.2
- [`794ce24`](https://github.com/junit-team/junit5/commit/794ce24890aef81de501cf1d847b4f4fa5ecf472) Fall back to display name if method name is blank
- [`b0f54b1`](https://github.com/junit-team/junit5/commit/b0f54b1a43b0250cf0bd2e0bf8a37e91c4646157) Back to snapshots for further development
- [`0214614`](https://github.com/junit-team/junit5/commit/0214614f4c97a438d804a0673b89b2c6139f4759) Release 5.6.1
- [`10ff918`](https://github.com/junit-team/junit5/commit/10ff91837e48e8e0af18d2d400ac9f9cda54ad70) Preserve original resource order
- Additional commits viewable in [compare view](https://github.com/junit-team/junit5/compare/r5.4.2...r5.6.2)
</details>
<br />

Updates `junit-jupiter-api` from 5.4.2 to 5.6.2
<details>
<summary>Release notes</summary>

*Sourced from [junit-jupiter-api's releases](https://github.com/junit-team/junit5/releases).*

> JUnit 5.6.2 = Platform 1.6.2 + Jupiter 5.6.2 + Vintage 5.6.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.2/release-notes/).
> 
> JUnit 5.6.1 = Platform 1.6.1 + Jupiter 5.6.1 + Vintage 5.6.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.1/release-notes/).
> 
> JUnit 5.6.0 = Platform 1.6.0 + Jupiter 5.6.0 + Vintage 5.6.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0/release-notes/).
> 
> JUnit 5.6.0-RC1 = Platform 1.6.0-RC1 + Jupiter 5.6.0-RC1 + Vintage 5.6.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-RC1/release-notes/).
> 
> JUnit 5.6.0-M1 = Platform 1.6.0-M1 + Jupiter 5.6.0-M1 + Vintage 5.6.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-M1/release-notes/).
> 
> JUnit 5.5.2 = Platform 1.5.2 + Jupiter 5.5.2 + Vintage 5.5.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.2/release-notes/).
> 
> JUnit 5.5.1 = Platform 1.5.1 + Jupiter 5.5.1 + Vintage 5.5.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.1/release-notes/).
> 
> JUnit 5.5.0 = Platform 1.5.0 + Jupiter 5.5.0 + Vintage 5.5.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0/release-notes/).
> 
> JUnit 5.5.0-RC2 = Platform 1.5.0-RC2 + Jupiter 5.5.0-RC2 + Vintage 5.5.0-RC2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC2/release-notes/).
> 
> JUnit 5.5.0-RC1 = Platform 1.5.0-RC1 + Jupiter 5.5.0-RC1 + Vintage 5.5.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC1/release-notes/).
> 
> JUnit 5.5.0-M1 = Platform 1.5.0-M1 + Jupiter 5.5.0-M1 + Vintage 5.5.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-M1/release-notes/).
</details>
<details>
<summary>Commits</summary>

- [`4e7a087`](https://github.com/junit-team/junit5/commit/4e7a087e052d982ec02a75da4a2c1f6cc34abde2) Release 5.6.2
- [`0be02cf`](https://github.com/junit-team/junit5/commit/0be02cf2e13a5de89b087be340a1d4b81d60eb69) Determine releaseBranch automatically based on version
- [`11ddd87`](https://github.com/junit-team/junit5/commit/11ddd8766b8e5ca661ca554a3c144673180fbc15) Avoid inner class cycle detection for non-matching predicate
- [`5cbfed5`](https://github.com/junit-team/junit5/commit/5cbfed57281dd70b3695b2daeaf35b7941a7e5e0) Remove irrelevant sections
- [`648121d`](https://github.com/junit-team/junit5/commit/648121d8b665836e5b88fa492462ab978431c777) Document [#2248](https://github-redirect.dependabot.com/junit-team/junit5/issues/2248) in release notes
- [`ef6e842`](https://github.com/junit-team/junit5/commit/ef6e842d1f1092d125abc17f636489f44daf5419) Add release notes for 5.6.2
- [`794ce24`](https://github.com/junit-team/junit5/commit/794ce24890aef81de501cf1d847b4f4fa5ecf472) Fall back to display name if method name is blank
- [`b0f54b1`](https://github.com/junit-team/junit5/commit/b0f54b1a43b0250cf0bd2e0bf8a37e91c4646157) Back to snapshots for further development
- [`0214614`](https://github.com/junit-team/junit5/commit/0214614f4c97a438d804a0673b89b2c6139f4759) Release 5.6.1
- [`10ff918`](https://github.com/junit-team/junit5/commit/10ff91837e48e8e0af18d2d400ac9f9cda54ad70) Preserve original resource order
- Additional commits viewable in [compare view](https://github.com/junit-team/junit5/compare/r5.4.2...r5.6.2)
</details>
<br />

Updates `junit-jupiter-params` from 5.4.2 to 5.6.2
<details>
<summary>Release notes</summary>

*Sourced from [junit-jupiter-params's releases](https://github.com/junit-team/junit5/releases).*

> JUnit 5.6.2 = Platform 1.6.2 + Jupiter 5.6.2 + Vintage 5.6.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.2/release-notes/).
> 
> JUnit 5.6.1 = Platform 1.6.1 + Jupiter 5.6.1 + Vintage 5.6.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.1/release-notes/).
> 
> JUnit 5.6.0 = Platform 1.6.0 + Jupiter 5.6.0 + Vintage 5.6.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0/release-notes/).
> 
> JUnit 5.6.0-RC1 = Platform 1.6.0-RC1 + Jupiter 5.6.0-RC1 + Vintage 5.6.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-RC1/release-notes/).
> 
> JUnit 5.6.0-M1 = Platform 1.6.0-M1 + Jupiter 5.6.0-M1 + Vintage 5.6.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.6.0-M1/release-notes/).
> 
> JUnit 5.5.2 = Platform 1.5.2 + Jupiter 5.5.2 + Vintage 5.5.2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.2/release-notes/).
> 
> JUnit 5.5.1 = Platform 1.5.1 + Jupiter 5.5.1 + Vintage 5.5.1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.1/release-notes/).
> 
> JUnit 5.5.0 = Platform 1.5.0 + Jupiter 5.5.0 + Vintage 5.5.0
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0/release-notes/).
> 
> JUnit 5.5.0-RC2 = Platform 1.5.0-RC2 + Jupiter 5.5.0-RC2 + Vintage 5.5.0-RC2
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC2/release-notes/).
> 
> JUnit 5.5.0-RC1 = Platform 1.5.0-RC1 + Jupiter 5.5.0-RC1 + Vintage 5.5.0-RC1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-RC1/release-notes/).
> 
> JUnit 5.5.0-M1 = Platform 1.5.0-M1 + Jupiter 5.5.0-M1 + Vintage 5.5.0-M1
> 
> See [Release Notes](http://junit.org/junit5/docs/5.5.0-M1/release-notes/).
</details>
<details>
<summary>Commits</summary>

- [`4e7a087`](https://github.com/junit-team/junit5/commit/4e7a087e052d982ec02a75da4a2c1f6cc34abde2) Release 5.6.2
- [`0be02cf`](https://github.com/junit-team/junit5/commit/0be02cf2e13a5de89b087be340a1d4b81d60eb69) Determine releaseBranch automatically based on version
- [`11ddd87`](https://github.com/junit-team/junit5/commit/11ddd8766b8e5ca661ca554a3c144673180fbc15) Avoid inner class cycle detection for non-matching predicate
- [`5cbfed5`](https://github.com/junit-team/junit5/commit/5cbfed57281dd70b3695b2daeaf35b7941a7e5e0) Remove irrelevant sections
- [`648121d`](https://github.com/junit-team/junit5/commit/648121d8b665836e5b88fa492462ab978431c777) Document [#2248](https://github-redirect.dependabot.com/junit-team/junit5/issues/2248) in release notes
- [`ef6e842`](https://github.com/junit-team/junit5/commit/ef6e842d1f1092d125abc17f636489f44daf5419) Add release notes for 5.6.2
- [`794ce24`](https://github.com/junit-team/junit5/commit/794ce24890aef81de501cf1d847b4f4fa5ecf472) Fall back to display name if method name is blank
- [`b0f54b1`](https://github.com/junit-team/junit5/commit/b0f54b1a43b0250cf0bd2e0bf8a37e91c4646157) Back to snapshots for further development
- [`0214614`](https://github.com/junit-team/junit5/commit/0214614f4c97a438d804a0673b89b2c6139f4759) Release 5.6.1
- [`10ff918`](https://github.com/junit-team/junit5/commit/10ff91837e48e8e0af18d2d400ac9f9cda54ad70) Preserve original resource order
- Additional commits viewable in [compare view](https://github.com/junit-team/junit5/compare/r5.4.2...r5.6.2)
</details>
<br />