### PR TITLE
Bump version.animal-sniffer from 1.17 to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <version.byte-buddy>1.10.1</version.byte-buddy>
 
         <!-- used both for plugin & annotations dependency -->
-        <version.animal-sniffer>1.17</version.animal-sniffer>
+        <version.animal-sniffer>1.18</version.animal-sniffer>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Bumps `version.animal-sniffer` from 1.17 to 1.18.

Updates `animal-sniffer-annotations` from 1.17 to 1.18
<details>
<summary>Commits</summary>

- [`fde3a20`](https://github.com/mojohaus/animal-sniffer/commit/fde3a201bc9e18717cd73d0ee9c0d7e859b6aee6) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`6c64478`](https://github.com/mojohaus/animal-sniffer/commit/6c644781451cfa50be9b63471f681a36fb65a1cb) back to 1.18-SNAPSHOT
- [`cf138c9`](https://github.com/mojohaus/animal-sniffer/commit/cf138c90ac61b4dbfd8b04dd3bd133f5ff756676) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`375d1d2`](https://github.com/mojohaus/animal-sniffer/commit/375d1d22baa520e4034e352c197966269fe89c09) use last mojo parent 50
- [`7ce5177`](https://github.com/mojohaus/animal-sniffer/commit/7ce5177ce01c94c2db081ee1ccf5a3de3a98c539) release upload failed back to 1.18-SNAPSHOT
- [`5b2107b`](https://github.com/mojohaus/animal-sniffer/commit/5b2107b2b0cddf26b6b09c477a40d203323d5b61) [maven-release-plugin] prepare for next development iteration
- [`312c17c`](https://github.com/mojohaus/animal-sniffer/commit/312c17cc86914ecaeec8bd8c157a5a570fb0c3f2) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`a781fbc`](https://github.com/mojohaus/animal-sniffer/commit/a781fbc0fd15cbd300e311a2b1f68d5a22c6aade) note on release flag in index page
- [`ea98b9e`](https://github.com/mojohaus/animal-sniffer/commit/ea98b9e0258dd75ede3674830fd20af29f94e155) add note on javac release flag
- [`fabc20f`](https://github.com/mojohaus/animal-sniffer/commit/fabc20f18bd46e6fc74937d7842745d3af119708) [#41](https://github-redirect.dependabot.com/mojohaus/animal-sniffer/issues/41) - exception type detection ([#47](https://github-redirect.dependabot.com/mojohaus/animal-sniffer/issues/47))
- Additional commits viewable in [compare view](https://github.com/mojohaus/animal-sniffer/compare/animal-sniffer-parent-1.17...animal-sniffer-parent-1.18)
</details>
<br />

Updates `animal-sniffer-maven-plugin` from 1.17 to 1.18
<details>
<summary>Commits</summary>

- [`fde3a20`](https://github.com/mojohaus/animal-sniffer/commit/fde3a201bc9e18717cd73d0ee9c0d7e859b6aee6) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`6c64478`](https://github.com/mojohaus/animal-sniffer/commit/6c644781451cfa50be9b63471f681a36fb65a1cb) back to 1.18-SNAPSHOT
- [`cf138c9`](https://github.com/mojohaus/animal-sniffer/commit/cf138c90ac61b4dbfd8b04dd3bd133f5ff756676) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`375d1d2`](https://github.com/mojohaus/animal-sniffer/commit/375d1d22baa520e4034e352c197966269fe89c09) use last mojo parent 50
- [`7ce5177`](https://github.com/mojohaus/animal-sniffer/commit/7ce5177ce01c94c2db081ee1ccf5a3de3a98c539) release upload failed back to 1.18-SNAPSHOT
- [`5b2107b`](https://github.com/mojohaus/animal-sniffer/commit/5b2107b2b0cddf26b6b09c477a40d203323d5b61) [maven-release-plugin] prepare for next development iteration
- [`312c17c`](https://github.com/mojohaus/animal-sniffer/commit/312c17cc86914ecaeec8bd8c157a5a570fb0c3f2) [maven-release-plugin] prepare release animal-sniffer-parent-1.18
- [`a781fbc`](https://github.com/mojohaus/animal-sniffer/commit/a781fbc0fd15cbd300e311a2b1f68d5a22c6aade) note on release flag in index page
- [`ea98b9e`](https://github.com/mojohaus/animal-sniffer/commit/ea98b9e0258dd75ede3674830fd20af29f94e155) add note on javac release flag
- [`fabc20f`](https://github.com/mojohaus/animal-sniffer/commit/fabc20f18bd46e6fc74937d7842745d3af119708) [#41](https://github-redirect.dependabot.com/mojohaus/animal-sniffer/issues/41) - exception type detection ([#47](https://github-redirect.dependabot.com/mojohaus/animal-sniffer/issues/47))
- Additional commits viewable in [compare view](https://github.com/mojohaus/animal-sniffer/compare/animal-sniffer-parent-1.17...animal-sniffer-parent-1.18)
</details>
<br />