### PR TITLE
Bump version.jetty-server from 9.4.11.v20180605 to 9.4.28.v20200408

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.slf4j>1.7.25</version.slf4j>
         <version.log4j>2.12.1</version.log4j>
         <version.spring>5.0.15.RELEASE</version.spring>
-        <version.jetty-server>9.4.11.v20180605</version.jetty-server>
+        <version.jetty-server>9.4.28.v20200408</version.jetty-server>
         <version.json-schema-validator>0.1.19</version.json-schema-validator>
         <version.byte-buddy>1.10.1</version.byte-buddy>
 


### PR DESCRIPTION
Bumps `version.jetty-server` from 9.4.11.v20180605 to 9.4.28.v20200408.

Updates `jetty-servlet` from 9.4.11.v20180605 to 9.4.28.v20200408
<details>
<summary>Commits</summary>

- [`ab228fd`](https://github.com/eclipse/jetty.project/commit/ab228fde9e55e9164c738d7fa121f8ac5acd51c9) Updating to version 9.4.28.v20200408
- [`10ddb6e`](https://github.com/eclipse/jetty.project/commit/10ddb6e673aad3ece0a16a3d04bcf03d04a1bf55) Merge branch 'jetty-9.4.x' of github.com:eclipse/jetty.project into jetty-9.4.x
- [`b9a9511`](https://github.com/eclipse/jetty.project/commit/b9a95119142cfe67afa28a72b74a8cd61e378aba) Merge pull request [#4748](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4748) from eclipse/jetty-9.4.x-4745-centralized-webapp-log...
- [`9079fa6`](https://github.com/eclipse/jetty.project/commit/9079fa63b3b4c852e9b62af9804c9a9daa4998e1) Improve keystore exception message when keystore is not valid ([#4759](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4759))
- [`103c22d`](https://github.com/eclipse/jetty.project/commit/103c22dc43fb2020761312eb3040c37fe396a70d) Merge pull request [#4754](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4754) from eclipse/jetty-9.4.x-4751-refresh_networktraffic...
- [`7ef0586`](https://github.com/eclipse/jetty.project/commit/7ef05860ee88e6621bed2002f008de656e62927d) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`4e3c0c8`](https://github.com/eclipse/jetty.project/commit/4e3c0c8cd7c05fb50774d5abda18bcca0181a7bf) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`8eb4bb9`](https://github.com/eclipse/jetty.project/commit/8eb4bb98a4c204ac3e8db038759257eb5668e21a) [@&#8203;RunAs](https://github.com/RunAs) not honoured ([#4743](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4743))
- [`4b28422`](https://github.com/eclipse/jetty.project/commit/4b2842265ac80641f88447de9f23666925cf2b7b) Issue [#4737](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4737) Ensure lifecycle callbacks happen for run-as and non async servle...
- [`cf0e3c5`](https://github.com/eclipse/jetty.project/commit/cf0e3c530f4ab878c8e0d83449fd9225ed8446f4) Issue [#4662](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4662) Ensure contextDestroyed called after filters and servlets destroy...
- Additional commits viewable in [compare view](https://github.com/eclipse/jetty.project/compare/jetty-9.4.11.v20180605...jetty-9.4.28.v20200408)
</details>
<br />

Updates `jetty-server` from 9.4.11.v20180605 to 9.4.28.v20200408
<details>
<summary>Commits</summary>

- [`ab228fd`](https://github.com/eclipse/jetty.project/commit/ab228fde9e55e9164c738d7fa121f8ac5acd51c9) Updating to version 9.4.28.v20200408
- [`10ddb6e`](https://github.com/eclipse/jetty.project/commit/10ddb6e673aad3ece0a16a3d04bcf03d04a1bf55) Merge branch 'jetty-9.4.x' of github.com:eclipse/jetty.project into jetty-9.4.x
- [`b9a9511`](https://github.com/eclipse/jetty.project/commit/b9a95119142cfe67afa28a72b74a8cd61e378aba) Merge pull request [#4748](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4748) from eclipse/jetty-9.4.x-4745-centralized-webapp-log...
- [`9079fa6`](https://github.com/eclipse/jetty.project/commit/9079fa63b3b4c852e9b62af9804c9a9daa4998e1) Improve keystore exception message when keystore is not valid ([#4759](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4759))
- [`103c22d`](https://github.com/eclipse/jetty.project/commit/103c22dc43fb2020761312eb3040c37fe396a70d) Merge pull request [#4754](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4754) from eclipse/jetty-9.4.x-4751-refresh_networktraffic...
- [`7ef0586`](https://github.com/eclipse/jetty.project/commit/7ef05860ee88e6621bed2002f008de656e62927d) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`4e3c0c8`](https://github.com/eclipse/jetty.project/commit/4e3c0c8cd7c05fb50774d5abda18bcca0181a7bf) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`8eb4bb9`](https://github.com/eclipse/jetty.project/commit/8eb4bb98a4c204ac3e8db038759257eb5668e21a) [@&#8203;RunAs](https://github.com/RunAs) not honoured ([#4743](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4743))
- [`4b28422`](https://github.com/eclipse/jetty.project/commit/4b2842265ac80641f88447de9f23666925cf2b7b) Issue [#4737](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4737) Ensure lifecycle callbacks happen for run-as and non async servle...
- [`cf0e3c5`](https://github.com/eclipse/jetty.project/commit/cf0e3c530f4ab878c8e0d83449fd9225ed8446f4) Issue [#4662](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4662) Ensure contextDestroyed called after filters and servlets destroy...
- Additional commits viewable in [compare view](https://github.com/eclipse/jetty.project/compare/jetty-9.4.11.v20180605...jetty-9.4.28.v20200408)
</details>
<br />

Updates `jetty-util` from 9.4.11.v20180605 to 9.4.28.v20200408
<details>
<summary>Commits</summary>

- [`ab228fd`](https://github.com/eclipse/jetty.project/commit/ab228fde9e55e9164c738d7fa121f8ac5acd51c9) Updating to version 9.4.28.v20200408
- [`10ddb6e`](https://github.com/eclipse/jetty.project/commit/10ddb6e673aad3ece0a16a3d04bcf03d04a1bf55) Merge branch 'jetty-9.4.x' of github.com:eclipse/jetty.project into jetty-9.4.x
- [`b9a9511`](https://github.com/eclipse/jetty.project/commit/b9a95119142cfe67afa28a72b74a8cd61e378aba) Merge pull request [#4748](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4748) from eclipse/jetty-9.4.x-4745-centralized-webapp-log...
- [`9079fa6`](https://github.com/eclipse/jetty.project/commit/9079fa63b3b4c852e9b62af9804c9a9daa4998e1) Improve keystore exception message when keystore is not valid ([#4759](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4759))
- [`103c22d`](https://github.com/eclipse/jetty.project/commit/103c22dc43fb2020761312eb3040c37fe396a70d) Merge pull request [#4754](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4754) from eclipse/jetty-9.4.x-4751-refresh_networktraffic...
- [`7ef0586`](https://github.com/eclipse/jetty.project/commit/7ef05860ee88e6621bed2002f008de656e62927d) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`4e3c0c8`](https://github.com/eclipse/jetty.project/commit/4e3c0c8cd7c05fb50774d5abda18bcca0181a7bf) Fixes [#4751](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4751) - Refresh NetworkTraffic* classes.
- [`8eb4bb9`](https://github.com/eclipse/jetty.project/commit/8eb4bb98a4c204ac3e8db038759257eb5668e21a) [@&#8203;RunAs](https://github.com/RunAs) not honoured ([#4743](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4743))
- [`4b28422`](https://github.com/eclipse/jetty.project/commit/4b2842265ac80641f88447de9f23666925cf2b7b) Issue [#4737](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4737) Ensure lifecycle callbacks happen for run-as and non async servle...
- [`cf0e3c5`](https://github.com/eclipse/jetty.project/commit/cf0e3c530f4ab878c8e0d83449fd9225ed8446f4) Issue [#4662](https://github-redirect.dependabot.com/eclipse/jetty.project/issues/4662) Ensure contextDestroyed called after filters and servlets destroy...
- Additional commits viewable in [compare view](https://github.com/eclipse/jetty.project/compare/jetty-9.4.11.v20180605...jetty-9.4.28.v20200408)
</details>
<br />