### PR TITLE
Bump version.slf4j from 1.7.25 to 1.7.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <version.junit-vintage-engine>5.3.2</version.junit-vintage-engine>
         <version.logback>1.2.3</version.logback>
         <version.okhttp>3.9.1</version.okhttp>
-        <version.slf4j>1.7.25</version.slf4j>
+        <version.slf4j>1.7.30</version.slf4j>
         <version.log4j>2.12.1</version.log4j>
         <version.spring>5.0.15.RELEASE</version.spring>
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>


### PR DESCRIPTION
Bumps `version.slf4j` from 1.7.25 to 1.7.30.

Updates `slf4j-api` from 1.7.25 to 1.7.30
<details>
<summary>Commits</summary>

- [`0b97c41`](https://github.com/qos-ch/slf4j/commit/0b97c416e42a184ff9728877b461c616187c58f7) move to 1.7.30
- [`c6c7a98`](https://github.com/qos-ch/slf4j/commit/c6c7a98a7ee1e71382348ae3e41ff7818dfafd65) fix SLF4J-469
- [`ca93154`](https://github.com/qos-ch/slf4j/commit/ca93154c79d7489ccc36a6957ebc2e74c34181ba) do not deploy slf4j-site
- [`d061e25`](https://github.com/qos-ch/slf4j/commit/d061e25477fa6928fbe1290a200c9a3442156b2b) this module is Apache 2.0 licensed
- [`e8ce694`](https://github.com/qos-ch/slf4j/commit/e8ce694e2e05999185479875e9f93aeaf7570b99) preapre release 1.7.29
- [`125e7cc`](https://github.com/qos-ch/slf4j/commit/125e7cca190c48fedcb92f377fd7361661f7537c) Merge pull request [#219](https://github-redirect.dependabot.com/qos-ch/slf4j/issues/219) from delgurth/1.7-maintenance-with-slf4j-466
- [`a7562cb`](https://github.com/qos-ch/slf4j/commit/a7562cb4b928c225192405b4d849246db60107d4) SLF4J-466: backport changes to 1.7
- [`9752c89`](https://github.com/qos-ch/slf4j/commit/9752c892fdf4d9d13ea020ac95fca2284ccbf68e) specify jdk8 in travis
- [`b44fbd5`](https://github.com/qos-ch/slf4j/commit/b44fbd53cc8bc87f40e5412e60495b19bbf07bb0) prepare release 1.7.28
- [`2a13746`](https://github.com/qos-ch/slf4j/commit/2a1374691f394b85b7da4a98d2b61105ba19e1b1) correct Automatic-Module-Name: org.apache.log4j
- Additional commits viewable in [compare view](https://github.com/qos-ch/slf4j/compare/v_1.7.25...v_1.7.30)
</details>
<br />

Updates `slf4j-simple` from 1.7.25 to 1.7.30
<details>
<summary>Commits</summary>

- [`0b97c41`](https://github.com/qos-ch/slf4j/commit/0b97c416e42a184ff9728877b461c616187c58f7) move to 1.7.30
- [`c6c7a98`](https://github.com/qos-ch/slf4j/commit/c6c7a98a7ee1e71382348ae3e41ff7818dfafd65) fix SLF4J-469
- [`ca93154`](https://github.com/qos-ch/slf4j/commit/ca93154c79d7489ccc36a6957ebc2e74c34181ba) do not deploy slf4j-site
- [`d061e25`](https://github.com/qos-ch/slf4j/commit/d061e25477fa6928fbe1290a200c9a3442156b2b) this module is Apache 2.0 licensed
- [`e8ce694`](https://github.com/qos-ch/slf4j/commit/e8ce694e2e05999185479875e9f93aeaf7570b99) preapre release 1.7.29
- [`125e7cc`](https://github.com/qos-ch/slf4j/commit/125e7cca190c48fedcb92f377fd7361661f7537c) Merge pull request [#219](https://github-redirect.dependabot.com/qos-ch/slf4j/issues/219) from delgurth/1.7-maintenance-with-slf4j-466
- [`a7562cb`](https://github.com/qos-ch/slf4j/commit/a7562cb4b928c225192405b4d849246db60107d4) SLF4J-466: backport changes to 1.7
- [`9752c89`](https://github.com/qos-ch/slf4j/commit/9752c892fdf4d9d13ea020ac95fca2284ccbf68e) specify jdk8 in travis
- [`b44fbd5`](https://github.com/qos-ch/slf4j/commit/b44fbd53cc8bc87f40e5412e60495b19bbf07bb0) prepare release 1.7.28
- [`2a13746`](https://github.com/qos-ch/slf4j/commit/2a1374691f394b85b7da4a98d2b61105ba19e1b1) correct Automatic-Module-Name: org.apache.log4j
- Additional commits viewable in [compare view](https://github.com/qos-ch/slf4j/compare/v_1.7.25...v_1.7.30)
</details>
<br />

Updates `jul-to-slf4j` from 1.7.25 to 1.7.30
<details>
<summary>Commits</summary>

- [`0b97c41`](https://github.com/qos-ch/slf4j/commit/0b97c416e42a184ff9728877b461c616187c58f7) move to 1.7.30
- [`c6c7a98`](https://github.com/qos-ch/slf4j/commit/c6c7a98a7ee1e71382348ae3e41ff7818dfafd65) fix SLF4J-469
- [`ca93154`](https://github.com/qos-ch/slf4j/commit/ca93154c79d7489ccc36a6957ebc2e74c34181ba) do not deploy slf4j-site
- [`d061e25`](https://github.com/qos-ch/slf4j/commit/d061e25477fa6928fbe1290a200c9a3442156b2b) this module is Apache 2.0 licensed
- [`e8ce694`](https://github.com/qos-ch/slf4j/commit/e8ce694e2e05999185479875e9f93aeaf7570b99) preapre release 1.7.29
- [`125e7cc`](https://github.com/qos-ch/slf4j/commit/125e7cca190c48fedcb92f377fd7361661f7537c) Merge pull request [#219](https://github-redirect.dependabot.com/qos-ch/slf4j/issues/219) from delgurth/1.7-maintenance-with-slf4j-466
- [`a7562cb`](https://github.com/qos-ch/slf4j/commit/a7562cb4b928c225192405b4d849246db60107d4) SLF4J-466: backport changes to 1.7
- [`9752c89`](https://github.com/qos-ch/slf4j/commit/9752c892fdf4d9d13ea020ac95fca2284ccbf68e) specify jdk8 in travis
- [`b44fbd5`](https://github.com/qos-ch/slf4j/commit/b44fbd53cc8bc87f40e5412e60495b19bbf07bb0) prepare release 1.7.28
- [`2a13746`](https://github.com/qos-ch/slf4j/commit/2a1374691f394b85b7da4a98d2b61105ba19e1b1) correct Automatic-Module-Name: org.apache.log4j
- Additional commits viewable in [compare view](https://github.com/qos-ch/slf4j/compare/v_1.7.25...v_1.7.30)
</details>
<br />