### PR TITLE
Bump version.byte-buddy from 1.10.1 to 1.10.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <version.spring>5.0.15.RELEASE</version.spring>
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>
         <version.json-schema-validator>0.1.19</version.json-schema-validator>
-        <version.byte-buddy>1.10.1</version.byte-buddy>
+        <version.byte-buddy>1.10.9</version.byte-buddy>
 
         <!-- used both for plugin & annotations dependency -->
         <version.animal-sniffer>1.17</version.animal-sniffer>


### PR DESCRIPTION
Bumps `version.byte-buddy` from 1.10.1 to 1.10.9.

Updates `byte-buddy` from 1.10.1 to 1.10.9
<details>
<summary>Release notes</summary>

*Sourced from [byte-buddy's releases](https://github.com/raphw/byte-buddy/releases).*

> ## Byte Buddy 1.10.9
> - Add validation for interface method modifiers.
> - Correct discovery of MacOs temp directory for Byte Buddy Agent `VirtualMachine`.
> - Add parallel processor for Byte Buddy build engine.
> - Add preprocessor for Byte Buddy build engine.
> - Explicitly load Java's `Module` from boot loader to avoid loading pseudo compiler target bundled with NetBeans.
> - Add convenience method for creating lookup-based class loading strategy with fallback to Unsafe for Java 8 and older.
> - Add caching for method, field and parameter description hashCode methods.
> 
> ## Byte Buddy 1.10.8
> - Adjust use of types of the `java.instrument` module to avoid errors if the module is not present on a JVM.
> 
> ## Byte Buddy 1.10.7
> - Correct discovery of old J9 VMs.
> - Correct invocation of `AgentBuilder.Listener` during retransformation.
> - Allow forbidding self-attachment using own artifact.
> - Add possibility to patch class file transformers.
> - Fix equality check for float and double primitives.
> - Add guards for annotation API to handle buggy reflection API with mandated parameters.
> - Update ASM.
> 
> ## Byte Buddy 1.10.6
> - Add experimental support for Java 15.
> - Allow `AndroidClassLoadingStrategy` to work with newer API level. 
> 
> ## Byte Buddy 1.10.5
> - Fixes Gradle plugin release to include correct dependency.
> - Fixes source jar release for shaded *byte-buddy* artifact.
> 
> ## Byte Buddy 1.10.4
> - Throw exception upon illegal creation of entry-only advice with local parameters to avoid verify error.
> - Remove escaping for execution path on Windows with spaces for Byte Buddy agent.
> - Fix J9 detection for older IBM-released versions of J9 in Byte Buddy agent.
> 
> ## Byte Buddy 1.10.3
> - Allow overriding the name of the native library for Windows attach emulation.
> - Use correct type pool in build plugin engine for decorators.
> - Fix attach emulation for OpenJ9 on MacOS.
> 
> ## Byte Buddy 1.10.2
> - Upgrade ASM to version 7.2.
> - Improve class file version detection for class files.
> - Check argument length of Windows attach emulation.
</details>
<details>
<summary>Changelog</summary>

*Sourced from [byte-buddy's changelog](https://github.com/raphw/byte-buddy/blob/master/release-notes.md).*

> ### 29. March 2020: version 1.10.9
> 
> - Add validation for interface method modifiers.
> - Correct discovery of MacOs temp directory for Byte Buddy Agent `VirtualMachine`.
> - Add parallel processor for Byte Buddy build engine.
> - Add preprocessor for Byte Buddy build engine.
> - Explicitly load Java's `Module` from boot loader to avoid loading pseudo compiler target bundled with NetBeans.
> - Add convenience method for creating lookup-based class loading strategy with fallback to Unsafe for Java 8 and older.
> - Add caching for method, field and parameter description hashCode methods.
> 
> ### 16. February 2020: version 1.10.8
> 
> - Adjust use of types of the `java.instrument` module to avoid errors if the module is not present on a JVM.
> 
> ### 21. January 2020: version 1.10.7
> 
> - Correct discovery of old J9 VMs.
> - Correct invocation of `AgentBuilder.Listener` during retransformation.
> - Allow forbidding self-attachment using own artifact.
> - Add possibility to patch class file transformers.
> - Fix equality check for float and double primitives.
> - Add guards for annotation API to handle buggy reflection API with mandated parameters.
> - Update ASM.
> 
> ### 19. December 2019: version 1.10.6
> 
> - Add experimental support for Java 15.
> - Allow `AndroidClassLoadingStrategy` to work with newer API level.
> 
> ### 11. December 2019: version 1.10.5
> 
> - Fixes Gradle plugin release to include correct dependency.
> - Fixes source jar release for shaded *byte-buddy* artifact.
> 
> ### 28. November 2019: version 1.10.4
> 
> - Throw exception upon illegal creation of entry-only advice with local parameters to avoid verify error.
> - Remove escaping for execution path on Windows with spaces for Byte Buddy agent.
> - Fix J9 detection for older IBM-released versions of J9 in Byte Buddy agent.
> 
> ### 8. November 2019: version 1.10.3
> 
> - Allow overriding the name of the native library for Windows attach emulation.
> - Use correct type pool in build plugin engine for decorators.
> - Fix attach emulation for OpenJ9 on MacOS.
> 
> ### 16. October 2019: version 1.10.2
> 
> - Upgrade ASM to version 7.2.
> - Improve class file version detection for class files.
></tr></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- [`ff68036`](https://github.com/raphw/byte-buddy/commit/ff68036434a57fb4910c6658deff35a6f3dd8ad9) [maven-release-plugin] prepare release byte-buddy-1.10.9
- [`0017237`](https://github.com/raphw/byte-buddy/commit/00172373cf96ffd8eafc0c36d5036b3fa8a7acd4) [release] Fix Gradle plugin version
- [`886c192`](https://github.com/raphw/byte-buddy/commit/886c1921de5eb426fdea655f4f741ae29efddf8e) [maven-release-plugin] prepare for next development iteration
- [`949e344`](https://github.com/raphw/byte-buddy/commit/949e3445d63bae13a2a10eedcdbd498cd3ce2039) [maven-release-plugin] prepare release byte-buddy-1.10.9
- [`34dd51a`](https://github.com/raphw/byte-buddy/commit/34dd51a68413836b6c0bd69a8fe190fe73311f0c) [release] New release
- [`6f5ff83`](https://github.com/raphw/byte-buddy/commit/6f5ff83d3c26f8af0c8024dd94f870ece8a1e158) Extend javadoc.
- [`fd579fa`](https://github.com/raphw/byte-buddy/commit/fd579fa5d7eafa5a0f1a9786a7001168abd359ab) Add convenience method for resolving a lookup based class loading strategy.
- [`1eba9dd`](https://github.com/raphw/byte-buddy/commit/1eba9ddf1f2944db18a8362da84ac0dfc2253b55) Add caching for expensive methods.
- [`6193017`](https://github.com/raphw/byte-buddy/commit/619301711fcfd9193b4bc6acec076dc80ac50023) Avoid security exception capture by specifying target loader.
- [`c4a2cb6`](https://github.com/raphw/byte-buddy/commit/c4a2cb6ef961d20511db0bf7f06379e6c45716dd) Merge pull request [#827](https://github-redirect.dependabot.com/raphw/byte-buddy/issues/827) from dinix2008/master
- Additional commits viewable in [compare view](https://github.com/raphw/byte-buddy/compare/byte-buddy-1.10.1...byte-buddy-1.10.9)
</details>
<br />

Updates `byte-buddy-agent` from 1.10.1 to 1.10.9
<details>
<summary>Release notes</summary>

*Sourced from [byte-buddy-agent's releases](https://github.com/raphw/byte-buddy/releases).*

> ## Byte Buddy 1.10.9
> - Add validation for interface method modifiers.
> - Correct discovery of MacOs temp directory for Byte Buddy Agent `VirtualMachine`.
> - Add parallel processor for Byte Buddy build engine.
> - Add preprocessor for Byte Buddy build engine.
> - Explicitly load Java's `Module` from boot loader to avoid loading pseudo compiler target bundled with NetBeans.
> - Add convenience method for creating lookup-based class loading strategy with fallback to Unsafe for Java 8 and older.
> - Add caching for method, field and parameter description hashCode methods.
> 
> ## Byte Buddy 1.10.8
> - Adjust use of types of the `java.instrument` module to avoid errors if the module is not present on a JVM.
> 
> ## Byte Buddy 1.10.7
> - Correct discovery of old J9 VMs.
> - Correct invocation of `AgentBuilder.Listener` during retransformation.
> - Allow forbidding self-attachment using own artifact.
> - Add possibility to patch class file transformers.
> - Fix equality check for float and double primitives.
> - Add guards for annotation API to handle buggy reflection API with mandated parameters.
> - Update ASM.
> 
> ## Byte Buddy 1.10.6
> - Add experimental support for Java 15.
> - Allow `AndroidClassLoadingStrategy` to work with newer API level. 
> 
> ## Byte Buddy 1.10.5
> - Fixes Gradle plugin release to include correct dependency.
> - Fixes source jar release for shaded *byte-buddy* artifact.
> 
> ## Byte Buddy 1.10.4
> - Throw exception upon illegal creation of entry-only advice with local parameters to avoid verify error.
> - Remove escaping for execution path on Windows with spaces for Byte Buddy agent.
> - Fix J9 detection for older IBM-released versions of J9 in Byte Buddy agent.
> 
> ## Byte Buddy 1.10.3
> - Allow overriding the name of the native library for Windows attach emulation.
> - Use correct type pool in build plugin engine for decorators.
> - Fix attach emulation for OpenJ9 on MacOS.
> 
> ## Byte Buddy 1.10.2
> - Upgrade ASM to version 7.2.
> - Improve class file version detection for class files.
> - Check argument length of Windows attach emulation.
</details>
<details>
<summary>Changelog</summary>

*Sourced from [byte-buddy-agent's changelog](https://github.com/raphw/byte-buddy/blob/master/release-notes.md).*

> ### 29. March 2020: version 1.10.9
> 
> - Add validation for interface method modifiers.
> - Correct discovery of MacOs temp directory for Byte Buddy Agent `VirtualMachine`.
> - Add parallel processor for Byte Buddy build engine.
> - Add preprocessor for Byte Buddy build engine.
> - Explicitly load Java's `Module` from boot loader to avoid loading pseudo compiler target bundled with NetBeans.
> - Add convenience method for creating lookup-based class loading strategy with fallback to Unsafe for Java 8 and older.
> - Add caching for method, field and parameter description hashCode methods.
> 
> ### 16. February 2020: version 1.10.8
> 
> - Adjust use of types of the `java.instrument` module to avoid errors if the module is not present on a JVM.
> 
> ### 21. January 2020: version 1.10.7
> 
> - Correct discovery of old J9 VMs.
> - Correct invocation of `AgentBuilder.Listener` during retransformation.
> - Allow forbidding self-attachment using own artifact.
> - Add possibility to patch class file transformers.
> - Fix equality check for float and double primitives.
> - Add guards for annotation API to handle buggy reflection API with mandated parameters.
> - Update ASM.
> 
> ### 19. December 2019: version 1.10.6
> 
> - Add experimental support for Java 15.
> - Allow `AndroidClassLoadingStrategy` to work with newer API level.
> 
> ### 11. December 2019: version 1.10.5
> 
> - Fixes Gradle plugin release to include correct dependency.
> - Fixes source jar release for shaded *byte-buddy* artifact.
> 
> ### 28. November 2019: version 1.10.4
> 
> - Throw exception upon illegal creation of entry-only advice with local parameters to avoid verify error.
> - Remove escaping for execution path on Windows with spaces for Byte Buddy agent.
> - Fix J9 detection for older IBM-released versions of J9 in Byte Buddy agent.
> 
> ### 8. November 2019: version 1.10.3
> 
> - Allow overriding the name of the native library for Windows attach emulation.
> - Use correct type pool in build plugin engine for decorators.
> - Fix attach emulation for OpenJ9 on MacOS.
> 
> ### 16. October 2019: version 1.10.2
> 
> - Upgrade ASM to version 7.2.
> - Improve class file version detection for class files.
></tr></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- [`ff68036`](https://github.com/raphw/byte-buddy/commit/ff68036434a57fb4910c6658deff35a6f3dd8ad9) [maven-release-plugin] prepare release byte-buddy-1.10.9
- [`0017237`](https://github.com/raphw/byte-buddy/commit/00172373cf96ffd8eafc0c36d5036b3fa8a7acd4) [release] Fix Gradle plugin version
- [`886c192`](https://github.com/raphw/byte-buddy/commit/886c1921de5eb426fdea655f4f741ae29efddf8e) [maven-release-plugin] prepare for next development iteration
- [`949e344`](https://github.com/raphw/byte-buddy/commit/949e3445d63bae13a2a10eedcdbd498cd3ce2039) [maven-release-plugin] prepare release byte-buddy-1.10.9
- [`34dd51a`](https://github.com/raphw/byte-buddy/commit/34dd51a68413836b6c0bd69a8fe190fe73311f0c) [release] New release
- [`6f5ff83`](https://github.com/raphw/byte-buddy/commit/6f5ff83d3c26f8af0c8024dd94f870ece8a1e158) Extend javadoc.
- [`fd579fa`](https://github.com/raphw/byte-buddy/commit/fd579fa5d7eafa5a0f1a9786a7001168abd359ab) Add convenience method for resolving a lookup based class loading strategy.
- [`1eba9dd`](https://github.com/raphw/byte-buddy/commit/1eba9ddf1f2944db18a8362da84ac0dfc2253b55) Add caching for expensive methods.
- [`6193017`](https://github.com/raphw/byte-buddy/commit/619301711fcfd9193b4bc6acec076dc80ac50023) Avoid security exception capture by specifying target loader.
- [`c4a2cb6`](https://github.com/raphw/byte-buddy/commit/c4a2cb6ef961d20511db0bf7f06379e6c45716dd) Merge pull request [#827](https://github-redirect.dependabot.com/raphw/byte-buddy/issues/827) from dinix2008/master
- Additional commits viewable in [compare view](https://github.com/raphw/byte-buddy/compare/byte-buddy-1.10.1...byte-buddy-1.10.9)
</details>
<br />