### PR TITLE
Bump version.okhttp from 3.9.1 to 4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <version.junit.vintage>4.12</version.junit.vintage>
         <version.junit-vintage-engine>5.3.2</version.junit-vintage-engine>
         <version.logback>1.2.3</version.logback>
-        <version.okhttp>3.9.1</version.okhttp>
+        <version.okhttp>4.5.0</version.okhttp>
         <version.slf4j>1.7.25</version.slf4j>
         <version.log4j>2.12.1</version.log4j>
         <version.spring>5.0.15.RELEASE</version.spring>


### PR DESCRIPTION
Bumps `version.okhttp` from 3.9.1 to 4.5.0.

Updates `okhttp` from 3.9.1 to 4.5.0
<details>
<summary>Changelog</summary>

*Sourced from [okhttp's changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md).*

> ## Version 4.5.0
> 
> _2020-04-06_
> 
> **This release fixes a severe bug where OkHttp incorrectly detected and recovered from unhealthy
> connections.** Stale or canceled connections were incorrectly attempted when they shouldn't have
> been, leading to rare cases of infinite retries. Please upgrade to this release!
> 
>  *  Fix: don't return stale DNS entries in `DnsOverHttps`. We were caching DNS results indefinitely
>     rather than the duration specified in the response's cache-control header.
>  *  Fix: Verify certificate IP addresses in canonical form. When a server presents a TLS certificate
>     containing an IP address we must match that address against the URL's IP address, even when the
>     two addresses are encoded differently, such as `192.168.1.1` and `0::0:0:FFFF:C0A8:101`. Note
>     that OkHttp incorrectly rejected valid certificates resulting in a failure to connect; at no
>     point were invalid certificates accepted.
>  *  New: `OkHttpClient.Builder.minWebSocketMessageToCompress()` configures a threshold for
>     compressing outbound web socket messages. Configure this with 0L to always compress outbound
>     messages and `Long.MAX_VALUE` to never compress outbound messages. The default is 1024L which
>     compresses messages of size 1 KiB and larger. (Inbound messages are compressed or not based on
>     the web socket server's configuration.)
>  *  New: Defer constructing `Inflater` and `Deflater` instances until they are needed. This saves
>     memory if web socket compression is negotiated but not used.
> 
> 
> ## Version 4.5.0-RC1
> 
> _2020-03-17_
> 
> **This release candidate turns on web socket compression.**
> 
> The [spec][rfc_7692] includes a sophisticated mechanism for client and server to negotiate
> compression features. We strive to offer great performance in our default configuration and so we're
> making compression the default for everyone starting with this release candidate.
> 
> Please be considerate of your servers and their operators as you roll out this release. Compression
> saves bandwidth but it costs CPU and memory! If you run into a problem you may need to adjust or
> disable the `permessage-deflate` compression settings on your server.
> 
> Note that OkHttp won't use compression when sending messages smaller than 1 KiB.
> 
>  *  Fix: Don't crash when the URL hostname contains an underscore on Android.
>  *  Fix: Change HTTP/2 to use a daemon thread for its socket reader. If you've ever seen a command
>     line application hang after all of the work is done, it may be due to a non-daemon thread like
>     this one.
>  *  New: Include suppressed exceptions when all routes to a target service fail.
> 
> 
> ## Version 4.4.1
> 
> _2020-03-08_
></tr></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- [`ca0c8d6`](https://github.com/square/okhttp/commit/ca0c8d6a1a9c24ebef74554527dd13d9d6234381) Prepare for release 4.5.0.
- [`c1150b0`](https://github.com/square/okhttp/commit/c1150b05e839b2cb2934fd181ebde89d2ec3dd05) Merge pull request [#5920](https://github-redirect.dependabot.com/square/okhttp/issues/5920) from square/health-raw-socket
- [`11ee29c`](https://github.com/square/okhttp/commit/11ee29cd78427f6abc0f0b69922cbbb905910b1e) Flag connection as unhealthy when underlying socket is closed.
- [`46fcf4f`](https://github.com/square/okhttp/commit/46fcf4f42c6471c4d13e5f2ba0eae6fdebe5d1bd) Fix for infinite caching in DoH ([#5918](https://github-redirect.dependabot.com/square/okhttp/issues/5918))
- [`7b07635`](https://github.com/square/okhttp/commit/7b07635f770498f78d31c6ba05c8af1bf9bc11ac) Defer class initialization to avoid spamming on Conscrypt errors (not for lan...
- [`3414fe4`](https://github.com/square/okhttp/commit/3414fe42b71f85e271dc4a39f4d4e8ba35792dfd) Close Android test properly in case it passes ([#5905](https://github-redirect.dependabot.com/square/okhttp/issues/5905))
- [`b7a41a9`](https://github.com/square/okhttp/commit/b7a41a9d3a1aa40c162cb5bda609f090e23eaae7) Merge pull request [#5913](https://github-redirect.dependabot.com/square/okhttp/issues/5913) from pau101/document-close-reason
- [`7e2922e`](https://github.com/square/okhttp/commit/7e2922e81512f2d3a4ff8c152d2db7927e5ce236) Document maximum close reason length
- [`4c1f65d`](https://github.com/square/okhttp/commit/4c1f65d1388ae8d5720530ca9b0094f7343eb1c8) Merge pull request [#5908](https://github-redirect.dependabot.com/square/okhttp/issues/5908) from yschimke/alpnz2
- [`4a753e7`](https://github.com/square/okhttp/commit/4a753e71cc9f8a33caf074c0e2eff6ead55fa022) New JDK 8 version for ALPN
- Additional commits viewable in [compare view](https://github.com/square/okhttp/compare/parent-3.9.1...parent-4.5.0)
</details>
<br />

Updates `logging-interceptor` from 3.9.1 to 4.5.0
<details>
<summary>Changelog</summary>

*Sourced from [logging-interceptor's changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md).*

> ## Version 4.5.0
> 
> _2020-04-06_
> 
> **This release fixes a severe bug where OkHttp incorrectly detected and recovered from unhealthy
> connections.** Stale or canceled connections were incorrectly attempted when they shouldn't have
> been, leading to rare cases of infinite retries. Please upgrade to this release!
> 
>  *  Fix: don't return stale DNS entries in `DnsOverHttps`. We were caching DNS results indefinitely
>     rather than the duration specified in the response's cache-control header.
>  *  Fix: Verify certificate IP addresses in canonical form. When a server presents a TLS certificate
>     containing an IP address we must match that address against the URL's IP address, even when the
>     two addresses are encoded differently, such as `192.168.1.1` and `0::0:0:FFFF:C0A8:101`. Note
>     that OkHttp incorrectly rejected valid certificates resulting in a failure to connect; at no
>     point were invalid certificates accepted.
>  *  New: `OkHttpClient.Builder.minWebSocketMessageToCompress()` configures a threshold for
>     compressing outbound web socket messages. Configure this with 0L to always compress outbound
>     messages and `Long.MAX_VALUE` to never compress outbound messages. The default is 1024L which
>     compresses messages of size 1 KiB and larger. (Inbound messages are compressed or not based on
>     the web socket server's configuration.)
>  *  New: Defer constructing `Inflater` and `Deflater` instances until they are needed. This saves
>     memory if web socket compression is negotiated but not used.
> 
> 
> ## Version 4.5.0-RC1
> 
> _2020-03-17_
> 
> **This release candidate turns on web socket compression.**
> 
> The [spec][rfc_7692] includes a sophisticated mechanism for client and server to negotiate
> compression features. We strive to offer great performance in our default configuration and so we're
> making compression the default for everyone starting with this release candidate.
> 
> Please be considerate of your servers and their operators as you roll out this release. Compression
> saves bandwidth but it costs CPU and memory! If you run into a problem you may need to adjust or
> disable the `permessage-deflate` compression settings on your server.
> 
> Note that OkHttp won't use compression when sending messages smaller than 1 KiB.
> 
>  *  Fix: Don't crash when the URL hostname contains an underscore on Android.
>  *  Fix: Change HTTP/2 to use a daemon thread for its socket reader. If you've ever seen a command
>     line application hang after all of the work is done, it may be due to a non-daemon thread like
>     this one.
>  *  New: Include suppressed exceptions when all routes to a target service fail.
> 
> 
> ## Version 4.4.1
> 
> _2020-03-08_
></tr></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- [`ca0c8d6`](https://github.com/square/okhttp/commit/ca0c8d6a1a9c24ebef74554527dd13d9d6234381) Prepare for release 4.5.0.
- [`c1150b0`](https://github.com/square/okhttp/commit/c1150b05e839b2cb2934fd181ebde89d2ec3dd05) Merge pull request [#5920](https://github-redirect.dependabot.com/square/okhttp/issues/5920) from square/health-raw-socket
- [`11ee29c`](https://github.com/square/okhttp/commit/11ee29cd78427f6abc0f0b69922cbbb905910b1e) Flag connection as unhealthy when underlying socket is closed.
- [`46fcf4f`](https://github.com/square/okhttp/commit/46fcf4f42c6471c4d13e5f2ba0eae6fdebe5d1bd) Fix for infinite caching in DoH ([#5918](https://github-redirect.dependabot.com/square/okhttp/issues/5918))
- [`7b07635`](https://github.com/square/okhttp/commit/7b07635f770498f78d31c6ba05c8af1bf9bc11ac) Defer class initialization to avoid spamming on Conscrypt errors (not for lan...
- [`3414fe4`](https://github.com/square/okhttp/commit/3414fe42b71f85e271dc4a39f4d4e8ba35792dfd) Close Android test properly in case it passes ([#5905](https://github-redirect.dependabot.com/square/okhttp/issues/5905))
- [`b7a41a9`](https://github.com/square/okhttp/commit/b7a41a9d3a1aa40c162cb5bda609f090e23eaae7) Merge pull request [#5913](https://github-redirect.dependabot.com/square/okhttp/issues/5913) from pau101/document-close-reason
- [`7e2922e`](https://github.com/square/okhttp/commit/7e2922e81512f2d3a4ff8c152d2db7927e5ce236) Document maximum close reason length
- [`4c1f65d`](https://github.com/square/okhttp/commit/4c1f65d1388ae8d5720530ca9b0094f7343eb1c8) Merge pull request [#5908](https://github-redirect.dependabot.com/square/okhttp/issues/5908) from yschimke/alpnz2
- [`4a753e7`](https://github.com/square/okhttp/commit/4a753e71cc9f8a33caf074c0e2eff6ead55fa022) New JDK 8 version for ALPN
- Additional commits viewable in [compare view](https://github.com/square/okhttp/compare/parent-3.9.1...parent-4.5.0)
</details>
<br />