### PR TITLE
Bump jmh.version from 1.21 to 1.23

### DIFF
--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.23</jmh.version>
         <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
         <maven.compiler.target>9</maven.compiler.target>


### PR DESCRIPTION
Bumps `jmh.version` from 1.21 to 1.23.

Updates `jmh-core` from 1.21 to 1.23

Updates `jmh-generator-annprocess` from 1.21 to 1.23