### PR TITLE
Bump version.jersey from 2.27 to 2.30.1

### DIFF
--- a/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
@@ -12,7 +12,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <version.jersey>2.27</version.jersey>
+        <version.jersey>2.30.1</version.jersey>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 


### PR DESCRIPTION
Bumps `version.jersey` from 2.27 to 2.30.1.

Updates `jersey-test-framework-provider-inmemory` from 2.27 to 2.30.1

Updates `jersey-hk2` from 2.27 to 2.30.1